### PR TITLE
Handle sfdx error responses correctly

### DIFF
--- a/src/uy/cattaneo/jsfdx/JSfdx.java
+++ b/src/uy/cattaneo/jsfdx/JSfdx.java
@@ -44,6 +44,7 @@ public class JSfdx {
         // Access any of the type attributes:
         // Get access token of your first org
         System.out.println(forceOrgListCmd.getResult().getNonScratchOrgs()[0].getAccessToken());
+        //System.out.println(forceOrgListCmd.getStatus());
     }
     
 }


### PR DESCRIPTION
Due to this bug https://github.com/forcedotcom/sfdx-core/issues/162, we can't wait for sfdx process' exit code (in case of error).